### PR TITLE
Add Ruby 3.2 to CI. Update checkout action. Use built in bundler-cache.

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -12,23 +12,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.1', '3.0', '2.7', '2.6', '2.5']
+        ruby-version: ['3.2', '3.1', '3.0', '2.7', '2.6', '2.5']
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby-version }}
-      - name: Install Bundler
-        run: |
-          gem install bundler
       - name: Install deps
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libcurl4-openssl-dev
-      - name: Install Ruby deps
-        run: |
-          bundle install --jobs 4 --retry 3
+      - uses: actions/checkout@v3
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
       - name: Run RSpec
         run: |
           bundle exec rspec

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -10,11 +10,11 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Set up Ruby 2.6
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: 2.6
       - name: Install RuboCop
         run: |
           gem install rubocop


### PR DESCRIPTION
## What is the purpose of this pull request?

Eliminates the Node v12 deprecation warnings on the Action run page

## What changes did you make? (overview)

Upgraded the checkout action from v2 to v3.
Updated the rubocop workflow to use the same approach for bundling as the specs workflow

## Is there anything you'd like reviewers to focus on?

## Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation
